### PR TITLE
Revert "always use ipv4"

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Display},
-    net::IpAddr,
     ops::Deref,
     str::FromStr,
     sync::{Arc, LazyLock},
@@ -610,7 +609,6 @@ pub async fn autocomplete(config: &Config, query: &str) -> eyre::Result<Vec<Stri
 
 pub static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::ClientBuilder::new()
-        .local_address(IpAddr::from_str("0.0.0.0").unwrap())
         // we pretend to be a normal browser so websites don't block us
         // (since we're not entirely a bot, we're acting on behalf of the user)
         .user_agent("Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0")


### PR DESCRIPTION
This reverts commit d496f3768d0ab76b142fe827e30c9acf8ab1dfd5.

Patch was tested and fixes connectivity issues on my end.

My server is hosted on an IPv6-only network with NAT64 and DNS64. Hence while ping, curl etc. works just fine towards IPv4-only hosts, with metasearch2 it fails with "Network unreachable", because yeah, that host is on no IPv4 network.

Reqwest makes reasonable decisions based on what getaddrinfo returns and which network protocols are configured on the local interfaces.

More background on how NAT64 works:
The network only assigns an IPv6 address to clients. If you do a DNS query for an IPv4-only domain, the local DNS server returns a NAT64 IP starting which is  64:ff9b:: + the IPv4 address. Requests to 64:ff9b::/96 are then handled by the NAT64 gateway.