### PR TITLE
fix marginalia

### DIFF
--- a/src/engines/search/marginalia.rs
+++ b/src/engines/search/marginalia.rs
@@ -38,7 +38,7 @@ pub fn request(query: &SearchQuery) -> RequestResponse {
     CLIENT
         .get(
             Url::parse_with_params(
-                "https://search.marginalia.nu/search",
+                "https://old-search.marginalia.nu/search",
                 &[
                     ("query", query.query.as_str()),
                     ("profile", config.args.profile.as_str()),


### PR DESCRIPTION
```toml
[engines]
bing = false
brave = false
google = false
rightdao = false
marginalia = true
```

this would show "no results" without the fix