### PR TITLE
switch to google custom search engine

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,8 @@ options you may want to change are:
   - image_search.enabled - add a tab for viewing image results for your query.
     this is disabled by default as the image proxy could be used to make GET
     requests to arbitrary URLs from your server.
+  - engines.google.custom_search_api_key - need to enable google. 100 free
+    searches a day: https://developers.google.com/custom-search/v1/overview
   - engines.google.weight - the ranking score multiplier for an engine, you can
     modify this if you prefer the results from certain engines.
 

--- a/config-default.toml
+++ b/config-default.toml
@@ -17,6 +17,11 @@ api = false
 # numbat = false
 # fend = true
 
+[engines.google]
+# enabled = true
+# 100 free searches a day: https://developers.google.com/custom-search/v1/overview
+# custom_search_api_key = ''
+
 [urls.replace]
 # "www.reddit.com" = "old.reddit.com"
 # "medium.com" = "scribe.rip"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,11 +51,9 @@ impl Default for EnginesConfig {
         use toml::value::Value;
 
         let mut map = HashMap::new();
-        // engines are enabled by default, so engines that aren't listed here are
-        // enabled
+        // engines are enabled by default, so engines that aren't listed here are enabled
 
         // main search engines
-        map.insert(Engine::Google, EngineConfig::new().with_weight(1.05));
         map.insert(Engine::Bing, EngineConfig::new().with_weight(1.0));
         map.insert(Engine::Brave, EngineConfig::new().with_weight(1.25));
         map.insert(
@@ -79,6 +77,10 @@ impl Default for EnginesConfig {
         );
 
         // additional search engines
+        map.insert(
+            Engine::Google,
+            EngineConfig::new().with_weight(1.05).disabled(),
+        );
         map.insert(
             Engine::GoogleScholar,
             EngineConfig::new().with_weight(0.50).disabled(),

--- a/src/engines/search/google.rs
+++ b/src/engines/search/google.rs
@@ -1,116 +1,74 @@
 use eyre::eyre;
-use scraper::{ElementRef, Selector};
+use scraper::Selector;
+use serde::Deserialize;
+use tracing::error;
 use tracing::warn;
 use url::Url;
 
-use crate::{
-    engines::{
-        EngineImageResult, EngineImagesResponse, EngineResponse, RequestResponse, SearchQuery,
-        CLIENT,
-    },
-    parse::{parse_html_response_with_opts, ParseOpts, QueryMethod},
+use crate::engines::{
+    Engine, EngineImageResult, EngineImagesResponse, EngineResponse, EngineSearchResult,
+    RequestResponse, SearchQuery, CLIENT,
 };
 
-pub async fn request(search: &SearchQuery) -> eyre::Result<RequestResponse> {
+#[derive(Deserialize)]
+pub struct GoogleConfig {
+    pub custom_search_api_key: String,
+}
+
+#[derive(Deserialize)]
+struct CustomSearchResponse {
+    items: Option<Vec<CustomSearchItem>>,
+}
+
+#[derive(Deserialize)]
+struct CustomSearchItem {
+    title: String,
+    link: String,
+    snippet: Option<String>,
+}
+
+pub async fn request(query: &SearchQuery) -> RequestResponse {
+    let config_toml = query.config.engines.get(Engine::Google).extra.clone();
+    let config: GoogleConfig = match toml::Value::Table(config_toml).try_into() {
+        Ok(args) => args,
+        Err(err) => {
+            error!("Failed to parse Google config: {err}");
+            return RequestResponse::None;
+        }
+    };
+
     let url = Url::parse_with_params(
-        "https://www.google.com/search",
+        "https://www.googleapis.com/customsearch/v1",
         &[
-            ("q", search.query.as_str()),
-            // nfpr makes it not try to autocorrect
-            ("nfpr", "1"),
-            ("filter", "0"),
-            ("start", "0"),
+            ("key", config.custom_search_api_key.as_str()),
+            ("cx", "d4e68b99b876541f0"), // https://git.lolcat.ca/lolcat/4get/src/commit/73f8472eeca07250dea9ea789e612f4a27d4ce5c/data/config.php#L175
+            ("q", query.query.as_ref()),
+            ("num", "10"),
         ],
     )
     .unwrap();
-
-    Ok(CLIENT.get(url).into())
+    CLIENT.get(url).into()
 }
 
 pub fn parse_response(body: &str) -> eyre::Result<EngineResponse> {
-    parse_html_response_with_opts(
-        body,
-        ParseOpts::new()
-            // xpd is weird, some results have it but it's usually used for ads?
-            // the :first-child filters out the ads though since for ads the first child is always a
-            // span
-            .result("[jscontroller=SC7lYd]")
-            .title("h3")
-            .href("a[href]")
-            .description(
-                "div[data-sncf='2'], div[data-sncf='1,2'], div[style='-webkit-line-clamp:2']",
-            )
-            .featured_snippet("block-component")
-            .featured_snippet_description(QueryMethod::Manual(Box::new(|el: &ElementRef| {
-                let mut description = String::new();
+    let response: CustomSearchResponse = serde_json::from_str(body)?;
+    let search_results = response
+        .items
+        .unwrap_or_default()
+        .into_iter()
+        .map(|item| EngineSearchResult {
+            title: item.title,
+            url: item.link,
+            description: item.snippet.unwrap_or_default(),
+        })
+        .collect();
 
-                // role="heading"
-                if let Some(heading_el) = el
-                    .select(&Selector::parse("div[role='heading']").unwrap())
-                    .next()
-                {
-                    description.push_str(&format!("{}\n\n", heading_el.text().collect::<String>()));
-                }
-
-                if let Some(description_container_el) = el
-                    .select(&Selector::parse("div[data-attrid='wa:/description'] > span:first-child").unwrap())
-                    .next()
-                {
-                    description.push_str(&iter_featured_snippet_children(&description_container_el));
-                }
-                else if let Some(description_list_el) = el
-                    .select(&Selector::parse("ul").unwrap())
-                    .next()
-                {
-                    // render as bullet points
-                    for li in description_list_el.select(&Selector::parse("li").unwrap()) {
-                        let text = li.text().collect::<String>();
-                        description.push_str(&format!("• {text}\n"));
-                    }
-                }
-
-                Ok(description)
-            })))
-            .featured_snippet_title(".g > div[lang] a h3, div[lang] > div[style='position:relative'] a h3")
-            .featured_snippet_href(QueryMethod::Manual(Box::new(|el: &ElementRef| {
-                let url = el
-                    .select(&Selector::parse(".g > div[lang] a:has(h3), div[lang] > div[style='position:relative'] a:has(h3)").unwrap())
-                    .next()
-                    .and_then(|n| n.value().attr("href"))
-                    .unwrap_or_default();
-                clean_url(url)
-            }))),
-    )
-}
-
-// Google autocomplete responses sometimes include clickable links that include
-// text that we shouldn't show.
-// We can filter for these by removing any elements matching
-// [data-ved]:not([data-send-open-event])
-fn iter_featured_snippet_children(el: &ElementRef) -> String {
-    let mut description = String::new();
-    recursive_iter_featured_snippet_children(&mut description, el);
-    description
-}
-fn recursive_iter_featured_snippet_children(description: &mut String, el: &ElementRef) {
-    for inner_node in el.children() {
-        match inner_node.value() {
-            scraper::Node::Text(t) => {
-                description.push_str(&t.text);
-            }
-            scraper::Node::Element(inner_el) => {
-                if inner_el.attr("data-ved").is_none()
-                    || inner_el.attr("data-send-open-event").is_some()
-                {
-                    recursive_iter_featured_snippet_children(
-                        description,
-                        &ElementRef::wrap(inner_node).unwrap(),
-                    );
-                }
-            }
-            _ => {}
-        }
-    }
+    Ok(EngineResponse {
+        search_results,
+        featured_snippet: None,
+        answer_html: None,
+        infobox_html: None,
+    })
 }
 
 pub fn request_autocomplete(query: &str) -> wreq::RequestBuilder {
@@ -226,19 +184,4 @@ pub fn parse_images_response(body: &str) -> eyre::Result<EngineImagesResponse> {
     }
 
     Ok(EngineImagesResponse { image_results })
-}
-
-fn clean_url(url: &str) -> eyre::Result<String> {
-    if url.starts_with("/url?q=") {
-        // get the q param
-        let url = Url::parse(format!("https://www.google.com{url}").as_str())?;
-        let q = url
-            .query_pairs()
-            .find(|(key, _)| key == "q")
-            .unwrap_or_default()
-            .1;
-        Ok(q.to_string())
-    } else {
-        Ok(url.to_string())
-    }
 }


### PR DESCRIPTION
copying 4get's homework: https://4get.ca/help-me.html
https://git.lolcat.ca/lolcat/4get/src/branch/master/scraper/google_api.php

- this disables the google search engine by default since it no longer works
- to use the new metasearch2 google engine, you must create and configure a `custom_search_api_key`
  without setting up billing, this gives you 100 free searches a day