### PR TITLE
fix bing

### DIFF
--- a/src/engines/search/bing.rs
+++ b/src/engines/search/bing.rs
@@ -1,5 +1,6 @@
 use base64::Engine;
 use eyre::eyre;
+use rand::Rng;
 use scraper::{ElementRef, Html, Selector};
 use tracing::warn;
 use url::Url;
@@ -10,14 +11,32 @@ use crate::{
 };
 
 pub async fn request(query: &str) -> wreq::RequestBuilder {
-    CLIENT.get(
-        Url::parse_with_params(
-            "https://www.bing.com/search",
-            // filters=rcrse:"1" makes it not try to autocorrect
-            &[("q", query), ("filters", "rcrse:\"1\"")],
-        )
-        .unwrap(),
+    let cvid = generate_cvid();
+    let url = Url::parse_with_params(
+        "https://www.bing.com/search",
+        &[
+            ("q", query),
+            ("pq", query),
+            ("cvid", &cvid),
+            ("filters", "rcrse:\"1\""), // filters=rcrse:"1" makes it not try to autocorrect
+            ("FORM", "PERE"),
+            ("ghc", "1"),
+            ("lq", "0"),
+            ("qs", "n"),
+            ("sk", ""),
+            ("sp", "-1"),
+        ],
     )
+    .unwrap();
+    CLIENT
+        .get(url)
+        .header("Cookie", &format!("SRCHHPGUSR=IG={}", cvid))
+}
+
+fn generate_cvid() -> String {
+    let mut bytes = [0u8; 16];
+    rand::rng().fill(&mut bytes);
+    bytes.iter().map(|b| format!("{:02X}", b)).collect()
 }
 
 pub fn parse_response(body: &str) -> eyre::Result<EngineResponse> {


### PR DESCRIPTION
pass `cvid`, which https://stackoverflow.com/a/60359248/385891 claims is the "conversation ID"

taking a hint from https://github.com/searxng/searxng/issues/4964#issuecomment-3386735311,
I was able to come up with some good test queries

before:
<img width="661" height="644" alt="image" src="https://github.com/user-attachments/assets/fcf61f1f-186f-48cd-8aa0-9dcd1512c702" />
<img width="657" height="549" alt="image" src="https://github.com/user-attachments/assets/b868e857-02eb-4d78-96d5-0112247410c1" />

after:
<img width="665" height="466" alt="image" src="https://github.com/user-attachments/assets/b5df0c00-2ca1-4bfb-a9f7-7f3b8c673afc" />
<img width="677" height="539" alt="image" src="https://github.com/user-attachments/assets/2e6e81c0-70cb-45ad-beb3-8b20293c1482" />

there are fewer results but they aren't bogus