### PR TITLE
use format query parameter for json response

### DIFF
--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -170,9 +170,11 @@ pub async fn get(
         config: config.clone().into(),
     };
 
-    let trying_to_use_api = query.request_headers.get("accept")
-        == Some(&"application/json".to_string())
-        || params.get("format").cloned() == Some("json".to_string());
+    let trying_to_use_api = query
+        .request_headers
+        .get("accept")
+        .is_some_and(|accept| accept == "application/json")
+        || params.get("format").is_some_and(|format| format == "json");
     if trying_to_use_api {
         if !config.api {
             return (StatusCode::FORBIDDEN, "API access is disabled").into_response();

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -170,8 +170,9 @@ pub async fn get(
         config: config.clone().into(),
     };
 
-    let trying_to_use_api =
-        query.request_headers.get("accept") == Some(&"application/json".to_string());
+    let trying_to_use_api = query.request_headers.get("accept")
+        == Some(&"application/json".to_string())
+        || params.get("format").cloned() == Some("json".to_string());
     if trying_to_use_api {
         if !config.api {
             return (StatusCode::FORBIDDEN, "API access is disabled").into_response();


### PR DESCRIPTION
Allows people to use json response formats via query parameter (is a really tiny PR)

