### PR TITLE
change Containerfile to glibc-based

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,21 +1,29 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.91-alpine as chef
+# based on glibc due to boring-sys2 dependency currently being broken on musl
+
+FROM rust:slim-bookworm AS builder
 WORKDIR /app
-
-FROM chef AS planner
+RUN apt-get update && apt-get install -y \
+    cmake \
+    golang \
+    perl \
+    clang \
+    libclang-dev \
+    llvm \
+    make \
+    g++ \
+    pkg-config \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
-COPY . .
+ENV RUST_BACKTRACE=1
 RUN cargo build --release
 
-FROM alpine:latest AS runtime
+FROM gcr.io/distroless/cc-debian12 AS runtime
 WORKDIR /app
-COPY --from=builder /app/config.toml /usr/local/bin/config.toml
 COPY --from=builder /app/target/release/metasearch /usr/local/bin/metasearch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ARG CONFIG
 ENV CONFIG=${CONFIG}
 EXPOSE 28019
-ENTRYPOINT /usr/local/bin/metasearch $CONFIG
+ENTRYPOINT ["/usr/local/bin/metasearch"]


### PR DESCRIPTION
Fixes #36 , which happened due to one of the dependencies no longer building on Musl.

The runtime is a tiny "distroless" Glibc image with libgcc and other libs needed for running included.

Thanks @unsecretised for building the build stage for this.