### PR TITLE
fix: replace unwrap() on TcpListener::bind with graceful stderr error + exit(1)

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -83,13 +83,21 @@ pub async fn run(config: Config) {
 
     info!("Listening on http://{bind_addr}");
 
-    let listener = tokio::net::TcpListener::bind(bind_addr).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("metasearch2: failed to bind to {bind_addr}: {e}");
+            std::process::exit(1);
+        });
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await
-    .unwrap();
+    .unwrap_or_else(|e| {
+        eprintln!("metasearch2: server error: {e}");
+        std::process::exit(1);
+    });
 }
 
 fn guess_mime_type(path: &str) -> &'static str {


### PR DESCRIPTION
## Problem
When the configured port is already in use, `TcpListener::bind()` fails and the `.unwrap()` on line 86 of `src/web/mod.rs` causes the process to panic with a generic error. The panic exits with code 101 and uses panic formatting, making it hard for wrapper scripts (like opencode-metasearch2) to detect the specific failure mode.

## Fix
Replace `.unwrap()` with `.unwrap_or_else()` that:
1. Prints a clear error message to **stderr** (machine-parseable prefix + address + OS error)
2. Exits with **code 1** (not panic code 101)

Same treatment applied to the `axum::serve().await.unwrap()` on line 91.

### Before
```
thread main panicked at src/web/mod.rs:86:67:
called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: Address already in use }
```

### After
```
metasearch2: failed to bind to 0.0.0.0:28019: Address already in use
```